### PR TITLE
Change HttpResponse to JsonResponse (for Django 1.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# django-ajax-validation
+A reusable application to preform ajax validation on django forms.
+
+Fork adapted for Django 1.9.
+
+# Install
+```
+pip install -e git+https://github.com/applecat/django-ajax-validation.git#egg=django-ajax-validation
+```

--- a/ajax_validation/views.py
+++ b/ajax_validation/views.py
@@ -24,7 +24,7 @@ def validate(request, *args, **kwargs):
             for f in form.forms:
                 for field in f.fields.keys():
                     formfields[f.add_prefix(field)] = f[field]
-                for field, error in f.errors.iteritems():
+                for field, error in f.errors.items():
                     errors[f.add_prefix(field)] = error
             if form.non_form_errors():
                 errors['__all__'] = form.non_form_errors()
@@ -35,10 +35,10 @@ def validate(request, *args, **kwargs):
         # if fields have been specified then restrict the error list
         if request.POST.getlist('fields'):
             fields = request.POST.getlist('fields') + ['__all__']
-            errors = dict([(key, val) for key, val in errors.iteritems() if key in fields])
+            errors = dict([(key, val) for key, val in errors.items() if key in fields])
 
         final_errors = {}
-        for key, val in errors.iteritems():
+        for key, val in errors.items():
             if '__all__' in key:
                 final_errors[key] = val
             elif not isinstance(formfields[key].field, forms.FileField):

--- a/ajax_validation/views.py
+++ b/ajax_validation/views.py
@@ -1,9 +1,7 @@
 from django import forms
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 from django.forms.formsets import BaseFormSet
-
-from ajax_validation.utils import LazyEncoder
 
 def validate(request, *args, **kwargs):
     form_class = kwargs.pop('form_class')
@@ -51,6 +49,5 @@ def validate(request, *args, **kwargs):
             'valid': False or not final_errors,
             'errors': final_errors,
         }
-    json_serializer = LazyEncoder()
-    return HttpResponse(json_serializer.encode(data), mimetype='application/json')
+    return JsonResponse(data)
 validate = require_POST(validate)


### PR DESCRIPTION
Since Django 1.7 we can use JsonResponse instead of HttpResponse for json responses.
And in Django 1.9 HttpResponse doesn't accept mimetype argument.
